### PR TITLE
feat(vimeo): add support for oembed poster images and displaying private videos

### DIFF
--- a/lib/embed/video.js
+++ b/lib/embed/video.js
@@ -52,6 +52,10 @@ export default class Video extends Observable(Embed) {
     return this.getAttribute('video-id')
   }
 
+  get videoPrivateId() {
+    return this.getAttribute('video-private-id') || null
+  }
+
   get posterImageUrl() {
     return this.getAttribute('poster-image') || this.impl.posterImageUrl
   }

--- a/lib/embed/video/type/vimeo.js
+++ b/lib/embed/video/type/vimeo.js
@@ -1,4 +1,6 @@
 import BaseType from '../type'
+import {VimeoAPIVideo} from "./vimeo/vimeoAPI";
+import {VimeoOembedVideo} from "./vimeo/vimeoOembed";
 
 const CSS = require('!css-loader!postcss-loader!sass-loader!./vimeo.scss').toString()
 
@@ -8,9 +10,19 @@ export class VimeoVideo extends BaseType {
   }
 
   get posterImageUrl() {
-    return this.element._api(
-      `/video/vimeo/${this.element.videoId}-poster-image`
-    )
+    if (this.element.videoPrivateId) {
+      return new VimeoOembedVideo(this.element).posterImageUrl(this.width, this.height)
+    } else {
+      return new VimeoAPIVideo(this.element).posterImageUrl()
+    }
+  }
+
+  get src() {
+    if (this.element.videoPrivateId) {
+      return new VimeoOembedVideo(this.element).src
+    } else {
+      return new VimeoAPIVideo(this.element).src
+    }
   }
 
   get iframe() {
@@ -18,7 +30,7 @@ export class VimeoVideo extends BaseType {
       <style>${CSS}</style>
       <div class="wrapper">
         <iframe
-          src="https://player.vimeo.com/video/${this.element.videoId}?autoplay=1#t=${this.element.startAt}"
+          src="${this.src}"
           width="${this.width}"
           height="${this.height}"
           frameborder="0"

--- a/lib/embed/video/type/vimeo/vimeoAPI.js
+++ b/lib/embed/video/type/vimeo/vimeoAPI.js
@@ -1,0 +1,15 @@
+export class VimeoAPIVideo {
+  constructor(element) {
+    this.element = element
+  }
+
+  posterImageUrl() {
+    return this.element._api(
+      `/video/vimeo/${this.element.videoId}-poster-image`
+    )
+  }
+
+  get src () {
+    return `https://player.vimeo.com/video/${this.element.videoId}?autoplay=1#t=${this.element.startAt}`
+  }
+}

--- a/lib/embed/video/type/vimeo/vimeoOembed.js
+++ b/lib/embed/video/type/vimeo/vimeoOembed.js
@@ -1,0 +1,23 @@
+export class VimeoOembedVideo {
+  constructor(element) {
+    this.element = element
+  }
+
+  posterImageUrl(width, height) {
+    let url = `/video/vimeo/oembed/${this.element.videoId}-poster-image`
+
+    if (this.element.videoPrivateId) {
+      url = `${url}?h=${this.element.videoPrivateId}`
+
+      if (width && height) url = `${url}&width=${width}&height=${height}`
+    } else {
+      if (width && height) url = `${url}?width=${width}&height=${height}`
+    }
+
+    return this.element._api(url)
+  }
+
+  get src () {
+    return `https://player.vimeo.com/video/${this.element.videoId}?h=${this.element.videoPrivateId}&autoplay=1#t=${this.element.startAt}`
+  }
+}


### PR DESCRIPTION
### Summary

- Add a feature for displaying private videos by adding a new attribute **video-private-id** for component, which will be used as **h** attribute for [vimeo played ](https://developer.vimeo.com/player/sdk/embed#embed-options-as-objects)
- Add feature for fetching private poster images using [vimeo oembed](https://developer.vimeo.com/api/oembed/videos)

### Motivation

Right now it's not possible to display private videos with poster image, with current solution it should work.

### Review

Try to display private vimeo video by adding private id key in **video-private-id**.  Then private vimeo video with poster image will be displayed 

### References

oembed approach for fetching poster images does not require to use authorization so this solution is ready to use. 
